### PR TITLE
swapCursor -> changeCursor in InboxFragment

### DIFF
--- a/RichPushSample/src/com/urbanairship/richpush/sample/InboxFragment.java
+++ b/RichPushSample/src/com/urbanairship/richpush/sample/InboxFragment.java
@@ -97,12 +97,7 @@ LoaderManager.LoaderCallbacks<Cursor> {
 
     @Override
     public void onLoadFinished(@SuppressWarnings("rawtypes") Loader loader, Cursor cursor) {
-        this.adapter.swapCursor(cursor);
-    }
-
-    @Override
-    public void onLoaderReset(@SuppressWarnings("rawtypes") Loader loader) {
-        this.adapter.swapCursor(null);
+        this.adapter.changeCursor(cursor);
     }
 
     // interfaces


### PR DESCRIPTION
changeCursor closes the old cursor before swapping in the new one.  this doesn't address the weird CalledFromWrongThreadException issue but it does prevent the associated crash without requiring any hacky exception handling in the UACursorWrapper.  
